### PR TITLE
Remove trailing parentheses from #undef

### DIFF
--- a/GCC/AVR_AVRDx/porthardware.h
+++ b/GCC/AVR_AVRDx/porthardware.h
@@ -174,21 +174,21 @@
             RTC.PER = RTC_PERIOD_HZ( configTICK_RATE_HZ );         \
             RTC.INTCTRL |= 1 << RTC_OVF_bp;                        \
         }
-        #undef TICK_TMR_STOP()   
-        #undef TICK_TMR_START()  
-        #undef TICK_TMR_READ()     
-        #undef TICK_INT_READY()    
+        #undef TICK_TMR_STOP
+        #undef TICK_TMR_START
+        #undef TICK_TMR_READ
+        #undef TICK_INT_READY
     #endif
 
 #else /* if ( configUSE_TIMER_INSTANCE == 0 ) */
     #undef TICK_INT_vect
     #undef INT_FLAGS
     #undef INT_MASK
-    #undef TICK_init()
-    #undef TICK_TMR_STOP()   
-    #undef TICK_TMR_START()                                    
-    #undef TICK_TMR_READ()     
-    #undef TICK_INT_READY()    
+    #undef TICK_init
+    #undef TICK_TMR_STOP  
+    #undef TICK_TMR_START
+    #undef TICK_TMR_READ
+    #undef TICK_INT_READY
     #error Invalid timer setting.
 #endif /* if ( configUSE_TIMER_INSTANCE == 0 ) */
 

--- a/GCC/AVR_Mega0/porthardware.h
+++ b/GCC/AVR_Mega0/porthardware.h
@@ -151,7 +151,7 @@
     #undef TICK_INT_vect
     #undef INT_FLAGS
     #undef INT_MASK
-    #undef TICK_init()
+    #undef TICK_init
     #error Invalid timer setting.
 #endif /* if ( configUSE_TIMER_INSTANCE == 0 ) */
 


### PR DESCRIPTION
Description
-----------
Trailing parentheses when undefining a macro
lead to compiler 'extra token' warnings

Test Steps
-----------
Followed this demo - https://www.freertos.org/microchip-avr-dx-demo.html

To test, I built with the changes and without. With the changes, no warnings for extra tokens were issued.

Obviously not the same compiler, but [this](https://learn.microsoft.com/en-us/cpp/preprocessor/hash-undef-directive-c-cpp?view=msvc-170) is still a useful reference for understanding the `#undef` directive

Related Issue
-----------
[Related forum post](https://forums.freertos.org/t/avr-gcc-warning-extra-tokens-at-end-of-undef-in-porthardware-h/16365/4)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
