### PR TITLE
Update the vApplicationGetPassiveIdleTaskMemory for SMP

### DIFF
--- a/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
+++ b/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
@@ -277,55 +277,72 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
     DebugP_assertNoLog(0);
 }
 
-static StaticTask_t xIdleTaskTCB;
-static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
-/* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must provide an
- * implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
- * used by the Idle task.
- */
-void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
-                                    StackType_t **ppxIdleTaskStackBuffer,
-                                    uint32_t *pulIdleTaskStackSize )
-{
-    /* Pass out a pointer to the StaticTask_t structure in which the Idle task’s
-     * state will be stored.
+#if ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 0 )
+    #if ( configNUMBER_OF_CORES == 1 )
+        static StaticTask_t xIdleTaskTCB;
+        static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+        /* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must provide an
+         * implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
+         * used by the Idle task.
+         */
+        void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                            StackType_t **ppxIdleTaskStackBuffer,
+                                            uint32_t *pulIdleTaskStackSize )
+        {
+            /* Pass out a pointer to the StaticTask_t structure in which the Idle task’s
+             * state will be stored.
+             */
+            *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+
+            /* Pass out the array that will be used as the Idle task’s stack. */
+            *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+            /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+             * Note that, as the array is necessarily of type StackType_t,
+             * configMINIMAL_STACK_SIZE is specified in words, not bytes.
+             */
+            *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+        }
+    #else
+        void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                        StackType_t ** ppxIdleTaskStackBuffer,
+                                        uint32_t * pulIdleTaskStackSize,
+                                        BaseType_t xCoreId )
+        {
+            static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
+            static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
+
+            *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
+            *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
+            *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+        }
+    #endif
+
+    static StaticTask_t xTimerTaskTCB;
+    static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
+    /* configSUPPORT_STATIC_ALLOCATION and configUSE_TIMERS are both set to 1, so the
+     * application must provide an implementation of vApplicationGetTimerTaskMemory()
+     * to provide the memory that is used by the Timer service task.
      */
-    *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+    void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
+                                         StackType_t **ppxTimerTaskStackBuffer,
+                                         uint32_t *pulTimerTaskStackSize )
+    {
+        /* Pass out a pointer to the StaticTask_t structure in which the Timer
+         * task’s state will be stored.
+         */
+        *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
 
-    /* Pass out the array that will be used as the Idle task’s stack. */
-    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+        /* Pass out the array that will be used as the Timer task’s stack. */
+        *ppxTimerTaskStackBuffer = uxTimerTaskStack;
 
-    /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
-     * Note that, as the array is necessarily of type StackType_t,
-     * configMINIMAL_STACK_SIZE is specified in words, not bytes.
-     */
-    *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
-}
-
-static StaticTask_t xTimerTaskTCB;
-static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];
-/* configSUPPORT_STATIC_ALLOCATION and configUSE_TIMERS are both set to 1, so the
- * application must provide an implementation of vApplicationGetTimerTaskMemory()
- * to provide the memory that is used by the Timer service task.
- */
-void vApplicationGetTimerTaskMemory( StaticTask_t **ppxTimerTaskTCBBuffer,
-                                     StackType_t **ppxTimerTaskStackBuffer,
-                                     uint32_t *pulTimerTaskStackSize )
-{
-    /* Pass out a pointer to the StaticTask_t structure in which the Timer
-     * task’s state will be stored.
-     */
-    *ppxTimerTaskTCBBuffer = &xTimerTaskTCB;
-
-    /* Pass out the array that will be used as the Timer task’s stack. */
-    *ppxTimerTaskStackBuffer = uxTimerTaskStack;
-
-    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
-     * Note that, as the array is necessarily of type StackType_t,
-     * configTIMER_TASK_STACK_DEPTH is specified in words, not bytes.
-     */
-    *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
-}
+        /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+         * Note that, as the array is necessarily of type StackType_t,
+         * configTIMER_TASK_STACK_DEPTH is specified in words, not bytes.
+         */
+        *pulTimerTaskStackSize = configTIMER_TASK_STACK_DEPTH;
+    }
+#endif
 
 /* This function is called when configUSE_IDLE_HOOK is 1 in FreeRTOSConfig.h */
 void vApplicationIdleHook( void )

--- a/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
+++ b/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
@@ -278,45 +278,40 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
 }
 
 #if ( configSUPPORT_STATIC_ALLOCATION == 1 ) && ( configKERNEL_PROVIDED_STATIC_MEMORY == 0 )
-    #if ( configNUMBER_OF_CORES == 1 )
+    static StaticTask_t xIdleTaskTCB;
+    static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+    /* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must provide an
+     * implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
+     * used by the Idle task.
+     */
+        void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                    StackType_t ** ppxIdleTaskStackBuffer,
+                                    uint32_t * pulIdleTaskStackSize )
+    {
         static StaticTask_t xIdleTaskTCB;
         static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
-        /* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must provide an
-         * implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
-         * used by the Idle task.
-         */
-        void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
-                                            StackType_t **ppxIdleTaskStackBuffer,
-                                            uint32_t *pulIdleTaskStackSize )
+
+        *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
+        *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
+        *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
+    }
+
+    #if ( configNUMBER_OF_CORES > 1 )
+
+        void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
+                                                   StackType_t ** ppxIdleTaskStackBuffer,
+                                                   uint32_t * pulIdleTaskStackSize,
+                                                   BaseType_t xPassiveIdleTaskIndex )
         {
-            /* Pass out a pointer to the StaticTask_t structure in which the Idle task’s
-             * state will be stored.
-             */
-            *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
+            static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
+            static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
 
-            /* Pass out the array that will be used as the Idle task’s stack. */
-            *ppxIdleTaskStackBuffer = uxIdleTaskStack;
-
-            /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
-             * Note that, as the array is necessarily of type StackType_t,
-             * configMINIMAL_STACK_SIZE is specified in words, not bytes.
-             */
+            *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
+            *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );
             *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
         }
-    #else
-        void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
-                                            StackType_t ** ppxIdleTaskStackBuffer,
-                                            uint32_t * pulIdleTaskStackSize,
-                                            BaseType_t xCoreId )
-        {
-            static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
-            static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];
 
-            *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xCoreId ] );
-            *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xCoreId ][ 0 ] );
-            *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
-        }
-    #endif
+    #endif /* #if ( configNUMBER_OF_CORES > 1 ) */
 
     static StaticTask_t xTimerTaskTCB;
     static StackType_t uxTimerTaskStack[ configTIMER_TASK_STACK_DEPTH ];

--- a/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
+++ b/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
@@ -305,9 +305,9 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
         }
     #else
         void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
-                                        StackType_t ** ppxIdleTaskStackBuffer,
-                                        uint32_t * pulIdleTaskStackSize,
-                                        BaseType_t xCoreId )
+                                            StackType_t ** ppxIdleTaskStackBuffer,
+                                            uint32_t * pulIdleTaskStackSize,
+                                            BaseType_t xCoreId )
         {
             static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES ];
             static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES ][ configMINIMAL_STACK_SIZE ];

--- a/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
+++ b/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/port.c
@@ -284,30 +284,35 @@ void vApplicationStackOverflowHook( TaskHandle_t xTask,
      * implementation of vApplicationGetIdleTaskMemory() to provide the memory that is
      * used by the Idle task.
      */
-        void vApplicationGetIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
-                                    StackType_t ** ppxIdleTaskStackBuffer,
-                                    uint32_t * pulIdleTaskStackSize )
+    void vApplicationGetIdleTaskMemory( StaticTask_t **ppxIdleTaskTCBBuffer,
+                                        StackType_t **ppxIdleTaskStackBuffer,
+                                        uint32_t *pulIdleTaskStackSize )
     {
-        static StaticTask_t xIdleTaskTCB;
-        static StackType_t uxIdleTaskStack[ configMINIMAL_STACK_SIZE ];
+        /* Pass out a pointer to the StaticTask_t structure in which the Idle task’s
+         * state will be stored.
+         */
+        *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
 
-        *ppxIdleTaskTCBBuffer = &( xIdleTaskTCB );
-        *ppxIdleTaskStackBuffer = &( uxIdleTaskStack[ 0 ] );
+        /* Pass out the array that will be used as the Idle task’s stack. */
+        *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+
+        /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
+         * Note that, as the array is necessarily of type StackType_t,
+         * configMINIMAL_STACK_SIZE is specified in words, not bytes.
+         */
         *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
     }
 
     #if ( configNUMBER_OF_CORES > 1 )
-
+        static StaticTask_t xPassiveIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
+        static StackType_t uxPassiveIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
         void vApplicationGetPassiveIdleTaskMemory( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                                    StackType_t ** ppxIdleTaskStackBuffer,
                                                    uint32_t * pulIdleTaskStackSize,
                                                    BaseType_t xPassiveIdleTaskIndex )
         {
-            static StaticTask_t xIdleTaskTCBs[ configNUMBER_OF_CORES - 1 ];
-            static StackType_t uxIdleTaskStacks[ configNUMBER_OF_CORES - 1 ][ configMINIMAL_STACK_SIZE ];
-
-            *ppxIdleTaskTCBBuffer = &( xIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
-            *ppxIdleTaskStackBuffer = &( uxIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );
+            *ppxIdleTaskTCBBuffer = &( xPassiveIdleTaskTCBs[ xPassiveIdleTaskIndex ] );
+            *ppxIdleTaskStackBuffer = &( uxPassiveIdleTaskStacks[ xPassiveIdleTaskIndex ][ 0 ] );
             *pulIdleTaskStackSize = configMINIMAL_STACK_SIZE;
         }
 


### PR DESCRIPTION
Fix get idle task memory for SMP

Description
-----------
SMP update the prototype for vApplicationGetPassiveIdleTaskMemory with the following
```c
void vApplicationGetPassiveIdleTaskMemory ( StaticTask_t ** ppxIdleTaskTCBBuffer,
                                    StackType_t ** ppxIdleTaskStackBuffer,
                                    uint32_t * pulIdleTaskStackSize,
                                    BaseType_t xPassiveIdleTaskIndex)
```

#### In this PR
* Update the `vApplicationGetPassiveIdleTaskMemory ` for SMP
* Consider in `configKERNEL_PROVIDED_STATIC_MEMORY` in the implementation.

Test Steps
-----------
N/A

Related Issue
-----------
<!-- If any, please provide issue ID. -->


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
