### PR TITLE
Remove incorrect portYIELD_FROM_ISR() functions 

### DIFF
--- a/GCC/AVR_AVRDx/port.c
+++ b/GCC/AVR_AVRDx/port.c
@@ -159,20 +159,6 @@ void vPortYield( void )
 /*-----------------------------------------------------------*/
 
 /*
- * Manual context switch callable from ISRs. The first thing
- * we do is save the registers so we can use a naked attribute.
- */
-void vPortYieldFromISR( void ) __attribute__( ( naked ) );
-void vPortYieldFromISR( void )
-{
-    portSAVE_CONTEXT();
-    vTaskSwitchContext();
-    portRESTORE_CONTEXT();
-    asm volatile ( "reti" );
-}
-/*-----------------------------------------------------------*/
-
-/*
  * Context switch function used by the tick.  This must be identical to
  * vPortYield() from the call to vTaskSwitchContext() onwards.  The only
  * difference from vPortYield() is the tick count is incremented as the

--- a/GCC/AVR_AVRDx/portmacro.h
+++ b/GCC/AVR_AVRDx/portmacro.h
@@ -95,8 +95,6 @@ typedef unsigned char    UBaseType_t;
 extern void vPortYield( void ) __attribute__( ( naked ) );
 #define portYIELD()             vPortYield()
 
-extern void vPortYieldFromISR( void ) __attribute__( ( naked ) );
-#define portYIELD_FROM_ISR()    vPortYieldFromISR()
 /*-----------------------------------------------------------*/
 
 /* Task function macros as described on the FreeRTOS.org WEB site. */


### PR DESCRIPTION
<!--- Title -->

Description
-----------
<!--- Describe your changes in detail. -->
Per discussion in #9 remove the incorrect `portYIELD_FROM_ISR()` function as it does nothing different than the default portYIELD() function.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->

Related Issue
-----------
<!-- If any, please provide issue ID. -->
#9 
Relevant [FreeRTOS Forum Post](https://forums.freertos.org/t/avr32-db-port-vportyieldfromisr-issue/17878)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
