### PR TITLE
Pass core ID to port lock macros

### DIFF
--- a/CCRH/U2x/port.c
+++ b/CCRH/U2x/port.c
@@ -220,12 +220,12 @@ void vPortTickISR( void );
     void vPortIPIHander( void );
     void vPortIPIRClearRequest( void );
 
-/* These below funtions implement recursive spinlock for exclusive access among
+/* These below functions implement recursive spinlock for exclusive access among
  * cores. The core will wait until lock will be available, whilst the core which
  * already had lock can acquire lock without waiting. This function could be
  * call from task and interrupt context, the critical section is called as in ISR */
-    void vPortRecursiveLockAcquire( BaseType_t xFromIsr );
-    void vPortRecursiveLockRelease( BaseType_t xFromIsr );
+    void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr );
+    void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr );
 
 #endif /* (configNUMBER_OF_CORES > 1) */
 
@@ -669,10 +669,9 @@ Lock_success:
     }
 
 /*-----------------------------------------------------------*/
-    void vPortRecursiveLockAcquire( BaseType_t xFromIsr )
+    void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr )
     {
         BaseType_t xSavedInterruptStatus;
-        BaseType_t xCoreID = xPortGET_CORE_ID();
         BaseType_t xBitPosition = ( xFromIsr == pdTRUE );
 
         xSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
@@ -686,10 +685,9 @@ Lock_success:
         portCLEAR_INTERRUPT_MASK_FROM_ISR( xSavedInterruptStatus );
     }
 
-    void vPortRecursiveLockRelease( BaseType_t xFromIsr )
+    void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr )
     {
         BaseType_t xSavedInterruptStatus;
-        BaseType_t xCoreID = xPortGET_CORE_ID();
         BaseType_t xBitPosition = ( xFromIsr == pdTRUE );
 
         xSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();

--- a/CCRH/U2x/portmacro.h
+++ b/CCRH/U2x/portmacro.h
@@ -157,18 +157,18 @@
     #endif /* if ( configNUMBER_OF_CORES > 1 ) */
 
     #if ( configNUMBER_OF_CORES == 1 )
-        #define portGET_ISR_LOCK()
-        #define portRELEASE_ISR_LOCK()
-        #define portGET_TASK_LOCK()
-        #define portRELEASE_TASK_LOCK()
+        #define portGET_ISR_LOCK( xCoreID )
+        #define portRELEASE_ISR_LOCK( xCoreID )
+        #define portGET_TASK_LOCK( xCoreID )
+        #define portRELEASE_TASK_LOCK( xCoreID )
     #else
-        extern void vPortRecursiveLockAcquire( BaseType_t xFromIsr );
-        extern void vPortRecursiveLockRelease( BaseType_t xFromIsr );
+        extern void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr );
+        extern void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr );
 
-        #define portGET_ISR_LOCK()         vPortRecursiveLockAcquire( pdTRUE )
-        #define portRELEASE_ISR_LOCK()     vPortRecursiveLockRelease( pdTRUE )
-        #define portGET_TASK_LOCK()        vPortRecursiveLockAcquire( pdFALSE )
-        #define portRELEASE_TASK_LOCK()    vPortRecursiveLockRelease( pdFALSE )
+        #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLockAcquire( xCoreID, pdTRUE )
+        #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLockRelease( xCoreID, pdTRUE )
+        #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLockAcquire( xCoreID, pdFALSE )
+        #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLockRelease( xCoreID, pdFALSE )
     #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 /*-----------------------------------------------------------*/

--- a/CCRH/U2x/portmacro.h
+++ b/CCRH/U2x/portmacro.h
@@ -165,10 +165,10 @@
         extern void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr );
         extern void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr );
 
-        #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLockAcquire( xCoreID, pdTRUE )
-        #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLockRelease( xCoreID, pdTRUE )
-        #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLockAcquire( xCoreID, pdFALSE )
-        #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLockRelease( xCoreID, pdFALSE )
+        #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLockAcquire( ( xCoreID ), pdTRUE )
+        #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLockRelease( ( xCoreID ), pdTRUE )
+        #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLockAcquire( ( xCoreID ), pdFALSE )
+        #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLockRelease( ( xCoreID ), pdFALSE )
     #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 /*-----------------------------------------------------------*/

--- a/GHS/U2x/port.c
+++ b/GHS/U2x/port.c
@@ -220,12 +220,12 @@ void vPortTickISR( void );
     void vPortIPIHander( void );
     void vPortIPIRClearRequest( void );
 
-/* These below funtions implement recursive spinlock for exclusive access among
+/* These below functions implement recursive spinlock for exclusive access among
  * cores. The core will wait until lock will be available, whilst the core which
  * already had lock can acquire lock without waiting. This function could be
  * call from task and interrupt context, the critical section is called as in ISR */
-    void vPortRecursiveLockAcquire( BaseType_t xFromIsr );
-    void vPortRecursiveLockRelease( BaseType_t xFromIsr );
+    void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr );
+    void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr );
 
 #endif /* (configNUMBER_OF_CORES > 1) */
 
@@ -665,10 +665,9 @@ static void prvSetupTimerInterrupt( void )
     }
 
 /*-----------------------------------------------------------*/
-    void vPortRecursiveLockAcquire( BaseType_t xFromIsr )
+    void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr )
     {
         BaseType_t xSavedInterruptStatus;
-        BaseType_t xCoreID = xPortGET_CORE_ID();
         BaseType_t xBitPosition = ( xFromIsr == pdTRUE );
 
         xSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();
@@ -682,10 +681,9 @@ static void prvSetupTimerInterrupt( void )
         portCLEAR_INTERRUPT_MASK_FROM_ISR( xSavedInterruptStatus );
     }
 
-    void vPortRecursiveLockRelease( BaseType_t xFromIsr )
+    void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr )
     {
         BaseType_t xSavedInterruptStatus;
-        BaseType_t xCoreID = xPortGET_CORE_ID();
         BaseType_t xBitPosition = ( xFromIsr == pdTRUE );
 
         xSavedInterruptStatus = portSET_INTERRUPT_MASK_FROM_ISR();

--- a/GHS/U2x/portmacro.h
+++ b/GHS/U2x/portmacro.h
@@ -178,10 +178,10 @@
         extern void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr );
         extern void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr );
 
-        #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLockAcquire( xCoreID, pdTRUE )
-        #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLockRelease( xCoreID, pdTRUE )
-        #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLockAcquire( xCoreID, pdFALSE )
-        #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLockRelease( xCoreID, pdFALSE )
+        #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLockAcquire( ( xCoreID ), pdTRUE )
+        #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLockRelease( ( xCoreID ), pdTRUE )
+        #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLockAcquire( ( xCoreID ), pdFALSE )
+        #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLockRelease( ( xCoreID ), pdFALSE )
     #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 /*-----------------------------------------------------------*/

--- a/GHS/U2x/portmacro.h
+++ b/GHS/U2x/portmacro.h
@@ -170,18 +170,18 @@
     #endif /* if ( configNUMBER_OF_CORES > 1 ) */
 
     #if ( configNUMBER_OF_CORES == 1 )
-        #define portGET_ISR_LOCK()
-        #define portRELEASE_ISR_LOCK()
-        #define portGET_TASK_LOCK()
-        #define portRELEASE_TASK_LOCK()
+        #define portGET_ISR_LOCK( xCoreID )
+        #define portRELEASE_ISR_LOCK( xCoreID )
+        #define portGET_TASK_LOCK( xCoreID )
+        #define portRELEASE_TASK_LOCK( xCoreID )
     #else
-        extern void vPortRecursiveLockAcquire( BaseType_t xFromIsr );
-        extern void vPortRecursiveLockRelease( BaseType_t xFromIsr );
+        extern void vPortRecursiveLockAcquire( BaseType_t xCoreID, BaseType_t xFromIsr );
+        extern void vPortRecursiveLockRelease( BaseType_t xCoreID, BaseType_t xFromIsr );
 
-        #define portGET_ISR_LOCK()         vPortRecursiveLockAcquire( pdTRUE )
-        #define portRELEASE_ISR_LOCK()     vPortRecursiveLockRelease( pdTRUE )
-        #define portGET_TASK_LOCK()        vPortRecursiveLockAcquire( pdFALSE )
-        #define portRELEASE_TASK_LOCK()    vPortRecursiveLockRelease( pdFALSE )
+        #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLockAcquire( xCoreID, pdTRUE )
+        #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLockRelease( xCoreID, pdTRUE )
+        #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLockAcquire( xCoreID, pdFALSE )
+        #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLockRelease( xCoreID, pdFALSE )
     #endif /* if ( configNUMBER_OF_CORES == 1 ) */
 
 /*-----------------------------------------------------------*/

--- a/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/portmacro.h
+++ b/TI/CORTEX_A53_64-BIT_TI_AM64_SMP/portmacro.h
@@ -187,11 +187,11 @@ void vPortTaskUsesFPU( void );
 #define portRTOS_LOCK_COUNT 2
 #define portMAX_CORE_COUNT 2
 
-#define portRELEASE_ISR_LOCK( xCoreID ) vPortRecursiveLock( xCoreID, ISR_LOCK, pdFALSE )
-#define portGET_ISR_LOCK( xCoreID )     vPortRecursiveLock( xCoreID, ISR_LOCK, pdTRUE )
+#define portRELEASE_ISR_LOCK( xCoreID ) vPortRecursiveLock( ( xCoreID ), ISR_LOCK, pdFALSE )
+#define portGET_ISR_LOCK( xCoreID )     vPortRecursiveLock( ( xCoreID ), ISR_LOCK, pdTRUE )
 
-#define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( xCoreID, TASK_LOCK, pdFALSE )
-#define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( xCoreID, TASK_LOCK, pdTRUE )
+#define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( ( xCoreID ), TASK_LOCK, pdFALSE )
+#define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( ( xCoreID ), TASK_LOCK, pdTRUE )
 
 /* Interrupt number to interrupt a core for task yield */
 #define YIELD_CORE_INTERRUPT_NO     (0U)


### PR DESCRIPTION
Description
-----------
Passes the core ID as an argument to the SMP lock macros `port{GET/RELEASE}_{TASK/ISR}_LOCK` in the following ports:

- CCRH/U2x
- GHS/U2x
- TI/CORTEX_A53_64-BIT_TI_AM64_SMP

This matches the kernel change introduced in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1212.

Test Steps
-----------
None.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1204

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.