### PR TITLE
xtensa: Implement xPortIsInsideInterrupt

### DIFF
--- a/Cadence/Xtensa/port.c
+++ b/Cadence/Xtensa/port.c
@@ -258,6 +258,11 @@ BaseType_t xPortStartScheduler( void )
     return pdFALSE;
 }
 
+BaseType_t xPortIsInsideInterrupt( void )
+{
+    return port_interruptNesting > 0 ? pdTRUE : pdFALSE;
+}
+
 //-----------------------------------------------------------------------------
 // Stop the scheduler.
 //-----------------------------------------------------------------------------

--- a/Cadence/Xtensa/portmacro.h
+++ b/Cadence/Xtensa/portmacro.h
@@ -218,6 +218,7 @@ BaseType_t xPortRaisePrivilege( void );
 #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS() do {} while (0)
 
 /* Kernel utilities. */
+BaseType_t xPortIsInsideInterrupt( void );
 void vPortYield( void );
 void _frxt_setup_switch( void );
 #define portYIELD()       vPortYield()


### PR DESCRIPTION
Implement support for this optional port API which provides a portable
way to check if the current executing code is within an interrupt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
