### PR TITLE
Add C29x port for TI F29H85x device

### DIFF
--- a/CCS/C2000_C29x_F29H85x/LICENSE
+++ b/CCS/C2000_C29x_F29H85x/LICENSE
@@ -1,0 +1,56 @@
+FreeRTOS Kernel <DEVELOPMENT BRANCH>
+Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+SPDX-License-Identifier: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+https://www.FreeRTOS.org
+https://github.com/FreeRTOS
+
+
+Copyright: Copyright (C) Texas Instruments Incorporated
+All rights reserved not granted herein.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions 
+are met:
+
+Redistributions of source code must retain the above copyright 
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the   
+distribution.
+
+Neither the name of Texas Instruments Incorporated nor the names of
+its contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/CCS/C2000_C29x_F29H85x/README.md
+++ b/CCS/C2000_C29x_F29H85x/README.md
@@ -1,0 +1,29 @@
+# Overview
+
+This directory contains the FreeRTOS port for the Texas Instruments F29H85x series of MCUs equipped with C2000 C29x core(s), developed using the c29clang compiler. Guidelines for using this port can be found below.
+
+## Software & Tool Dependencies
+
+- [FreeRTOS Kernel](https://github.com/FreeRTOS/FreeRTOS-Kernel/releases/tag/V11.2.0) **v11.2.0**
+- [C29-CGT](https://www.ti.com/tool/download/C29-CGT/1.0.0.LTS) **v1.0.0LTS**
+- [Code Composer Studio IDE](https://www.ti.com/tool/download/CCSTUDIO) **v20x**
+- [F29H85X-SDK](https://www.ti.com/tool/download/F29H85X-SDK/1.01.00.00) **v1.01.00.00** (or above)
+
+## Test Project
+
+The standard test project for validating port functionality can be found in the [Partner-Supported Demos](https://github.com/FreeRTOS/FreeRTOS-Partner-Supported-Demos/tree/main/C2000_C29x_F29H85x_CCS/) repository. Additional example projects can be found in the F29H85X-SDK.
+
+## Notes
+
+- `configUSE_MINI_LIST_ITEM` must be set to 0 for C29x port. Refer to [configuration docs](https://www.freertos.org/a00110.html#configUSE_MINI_LIST_ITEM) for more information
+- Currently, the c29clang compiler utilizes some FPU registers even when FPU operations are not done. Therefore FPU context are *always* saved & restored
+- Default resources utilized:
+    - **CPUTIMER2** & **INT_TIMER2** : Timer and PIPE interrupt used for kernel tick
+    - **INT_SW1** : PIPE Interrupt used for yield (task switch). Note that this interrupt MUST ALWAYS be configured to the lowest possible priority
+
+  These resources are configured in *`portdefines.h`*. It is recommended to use the default configurations. However, if these are updated during development, make sure to Clean & Rebuild your CCS project.
+
+## Support
+
+- Additional examples, tools and documentation are available in the F29H85X-SDK. Refer to the [SDK documentation](https://software-dl.ti.com/C2000/docs/f29h85x-sdk/latest/docs/html/index.html) for further details  
+- For further support/queries, please raise a query on the Texas Instruments [E2E Support Forum](https://e2e.ti.com/)  

--- a/CCS/C2000_C29x_F29H85x/port.c
+++ b/CCS/C2000_C29x_F29H85x/port.c
@@ -1,0 +1,235 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+//	Copyright: Copyright (C) Texas Instruments Incorporated
+//	All rights reserved not granted herein.
+//
+//  Redistribution and use in source and binary forms, with or without 
+//  modification, are permitted provided that the following conditions 
+//  are met:
+//
+//  Redistributions of source code must retain the above copyright 
+//  notice, this list of conditions and the following disclaimer.
+//
+//  Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the 
+//  documentation and/or other materials provided with the   
+//  distribution.
+//
+//  Neither the name of Texas Instruments Incorporated nor the names of
+//  its contributors may be used to endorse or promote products derived
+//  from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+//-------------------------------------------------------------------------------------------------
+// Scheduler includes.
+//-------------------------------------------------------------------------------------------------
+#include "FreeRTOS.h"
+#include "task.h"
+
+#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+    /* Check the configuration. */
+    #if ( configMAX_PRIORITIES > 32 )
+        #error configUSE_PORT_OPTIMISED_TASK_SELECTION can only be set to 1 when configMAX_PRIORITIES is less than or equal to 32.
+    #endif
+#endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
+
+//-------------------------------------------------------------------------------------------------
+// Implementation of functions defined in portable.h for the C29x port.
+//-------------------------------------------------------------------------------------------------
+
+// Constants required for hardware setup.
+#define portINITIAL_CRITICAL_NESTING    ( ( uint16_t ) 10 )
+#define portFLAGS_INT_ENABLED           ( ( StackType_t ) 0x010000 )  // DSTS LP INT ENABLE 
+
+// Register descriptions of C29 Architecture
+#define A_REGISTERS             16  // Addressing registers
+#define D_REGISTERS             16  // Fixed point registers
+#define M_REGISTERS             32  // Floating point registers
+#define A4_REGISTER_POSITION    4U
+
+//
+// DO NOT MAKE as pdFALSE, the C29 compiler currently uses some FPU registers even when FPU
+// operations are not done, hence we should save/restore FPU always
+//
+#define TASK_HAS_FPU_CONTEXT_ON_TASK_START  pdTRUE
+
+void vPortSetupTimerInterrupt( void );
+void vPortSetupSWInterrupt( void );
+
+// Each task maintains a count of the critical section nesting depth.  Each
+// time a critical section is entered the count is incremented.  Each time a
+// critical section is exited the count is decremented - with interrupts only
+// being re-enabled if the count is zero.
+//
+// ulCriticalNesting will get set to zero when the scheduler starts, but must
+// not be initialised to zero as this will cause problems during the startup
+// sequence.
+//
+// ulCriticalNesting should be 32 bit value to keep stack alignment unchanged.
+volatile uint32_t ulCriticalNesting = portINITIAL_CRITICAL_NESTING;
+
+// 
+// Saved as part of the task context. Value set here has no effect.
+// Value set in pxPortInitialiseStack is the initial value when a task starts
+// 
+uint32_t ulTaskHasFPUContext = TASK_HAS_FPU_CONTEXT_ON_TASK_START;
+
+//-------------------------------------------------------------------------------------------------
+// Initialise the stack of a task to look exactly as if
+// timer interrupt was executed.
+//-------------------------------------------------------------------------------------------------
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+{
+    uint16_t i;
+    uint16_t base = 0;
+
+    pxTopOfStack[base] = (uint32_t)vPortEndScheduler; 
+    base+=1;    // Alignment
+    pxTopOfStack[base] = 0x07F90001; 
+    base+=1;    // Alignment , DSTS if RETI
+    pxTopOfStack[base]  = 0xABABABAB; 
+    base+=1 ;   // A14
+    pxTopOfStack[base] = ((uint32_t)pxCode) & 0xFFFFFFFEU;
+    base+=1;    //RPC or PC (first task) after return
+    pxTopOfStack[base]  = 0x07F90001; 
+    base+=1;    // DSTS
+    pxTopOfStack[base]  = 0x00020101; 
+    base+=1;    // ESTS
+
+    // Fill the rest of the registers with dummy values.
+    for(i = 0; i <= (A_REGISTERS + D_REGISTERS + M_REGISTERS -2 -1); i++)
+    {
+        uint32_t value  = 0xDEADDEAD;
+
+        // Function parameters are passed in A4.
+        if(i == A4_REGISTER_POSITION)
+        {
+            value = (uint32_t)pvParameters;
+        }
+        pxTopOfStack[base + i] = value;
+    }
+    base += i ;
+
+    // Save (or) Don't save FPU registers when a task starts
+    pxTopOfStack[base] = TASK_HAS_FPU_CONTEXT_ON_TASK_START; 
+    base+=1;    // FPU context
+    base+=1;    // Alignment
+
+    // Return a pointer to the top of the stack we have generated so this can
+    // be stored in the task control block for the task.
+    return pxTopOfStack + base;
+}
+
+//-------------------------------------------------------------------------------------------------
+// See header file for description.
+//-------------------------------------------------------------------------------------------------
+BaseType_t xPortStartScheduler(void)
+{
+    // Yield interrupt
+    vPortSetupSWInterrupt();
+    // Tick timer interrupt
+    vPortSetupTimerInterrupt();
+
+    ulCriticalNesting = 0;
+
+    portENABLE_INTERRUPTS();
+    portRESTORE_FIRST_CONTEXT();
+
+    // This line should not be reached
+    return pdFAIL;
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortEndScheduler( void )
+{
+    // It is unlikely that the C29x port will get stopped.
+    // If required simply disable the tick interrupt here.
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortSetupTimerInterrupt( void )
+{
+    CPUTimer_stopTimer(PORT_TICK_TIMER_BASE);
+    CPUTimer_setPeriod(PORT_TICK_TIMER_BASE, ((uint32_t)((configCPU_CLOCK_HZ / configTICK_RATE_HZ))));
+    CPUTimer_setPreScaler(PORT_TICK_TIMER_BASE, 0U);
+    CPUTimer_reloadTimerCounter(PORT_TICK_TIMER_BASE);
+    CPUTimer_setEmulationMode(PORT_TICK_TIMER_BASE, CPUTIMER_EMULATIONMODE_STOPAFTERNEXTDECREMENT);
+    CPUTimer_clearOverflowFlag(PORT_TICK_TIMER_BASE);
+    CPUTimer_enableInterrupt(PORT_TICK_TIMER_BASE);
+
+    Interrupt_disable(PORT_TICK_TIMER_INT);
+    Interrupt_clearFlag(PORT_TICK_TIMER_INT);
+    Interrupt_clearOverflowFlag(PORT_TICK_TIMER_INT);
+    Interrupt_register(PORT_TICK_TIMER_INT, &portTICK_ISR);
+    Interrupt_setPriority(PORT_TICK_TIMER_INT, PORT_TICK_TIMER_INT_PRI);
+    Interrupt_enable(PORT_TICK_TIMER_INT);
+
+    CPUTimer_startTimer(PORT_TICK_TIMER_BASE);
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortSetupSWInterrupt( void )
+{
+    Interrupt_disable(PORT_TASK_SWITCH_INT);
+    Interrupt_clearFlag(PORT_TASK_SWITCH_INT);
+    Interrupt_clearOverflowFlag(PORT_TASK_SWITCH_INT);
+    Interrupt_register(PORT_TASK_SWITCH_INT, &vPortYield);
+    Interrupt_setPriority(PORT_TASK_SWITCH_INT, PORT_TASK_SWITCH_INT_PRI);
+    Interrupt_enable(PORT_TASK_SWITCH_INT);
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortEnterCritical( void )
+{
+    portDISABLE_INTERRUPTS();
+    ulCriticalNesting++;
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortExitCritical( void )
+{
+    ulCriticalNesting--;
+    if( ulCriticalNesting == 0 )
+    {
+        portENABLE_INTERRUPTS();
+    }
+}
+

--- a/CCS/C2000_C29x_F29H85x/portasm.S
+++ b/CCS/C2000_C29x_F29H85x/portasm.S
@@ -1,0 +1,210 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+//	Copyright: Copyright (C) Texas Instruments Incorporated
+//	All rights reserved not granted herein.
+//
+//  Redistribution and use in source and binary forms, with or without 
+//  modification, are permitted provided that the following conditions 
+//  are met:
+//
+//  Redistributions of source code must retain the above copyright 
+//  notice, this list of conditions and the following disclaimer.
+//
+//  Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the 
+//  documentation and/or other materials provided with the   
+//  distribution.
+//
+//  Neither the name of Texas Instruments Incorporated nor the names of
+//  its contributors may be used to endorse or promote products derived
+//  from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+    #include "portdefines.h"
+    .extern pxCurrentTCB
+    .extern xTaskIncrementTick
+    .extern vTaskSwitchContext
+    .extern ulTaskHasFPUContext
+
+    .global portTICK_ISR
+    .global portRESTORE_FIRST_CONTEXT
+    .global vPortYield
+
+
+    .macro portSAVE_CONTEXT
+        ST.32 *(A15++#8), A14
+        || MV A14, RPC
+        ST.32 *(A15-#4), A14
+        ST.32 *(A15++#8), DSTS
+        ST.32 *(A15-#4), ESTS
+        ST.64 *(A15++#8), XA0
+        ST.64 *(A15++#8), XA2
+        ST.64 *(A15++#8), XA4
+        ST.64 *(A15++#8), XA6
+        ST.64 *(A15++#8), XA8
+        ST.64 *(A15++#8), XA10
+        ST.64 *(A15++#8), XA12
+        ST.64 *(A15++#8), XD0
+        ST.64 *(A15++#8), XD2
+        ST.64 *(A15++#8), XD4
+        ST.64 *(A15++#8), XD6
+        
+        ;Check if task has FPU context
+        || LD.32	 D0, @ulTaskHasFPUContext
+
+        ST.64 *(A15++#8), XD8
+        || BCMPZD  .+0x54, D.EQ, D0
+        ST.64 *(A15++#8), XD10
+        ST.64 *(A15++#8), XD12
+        ST.64 *(A15++#8), XD14
+
+        ST.64 *(A15++#8), XM0
+        ST.64 *(A15++#8), XM2
+        ST.64 *(A15++#8), XM4
+        ST.64 *(A15++#8), XM6
+        ST.64 *(A15++#8), XM8
+        ST.64 *(A15++#8), XM10
+        ST.64 *(A15++#8), XM12
+        ST.64 *(A15++#8), XM14
+        ST.64 *(A15++#8), XM16
+        ST.64 *(A15++#8), XM18
+        ST.64 *(A15++#8), XM20
+        ST.64 *(A15++#8), XM22
+        ST.64 *(A15++#8), XM24
+        ST.64 *(A15++#8), XM26
+        ST.64 *(A15++#8), XM28
+        ST.64 *(A15++#8), XM30
+
+        ; Store FPU context indicator
+        ST.32 *(A15++#8), D0 
+        ; Store the new top of stack for the task.
+        || LD.32	A14, @pxCurrentTCB
+        ST.32	*A14, A15
+    .endm
+
+    .macro portRESTORE_CONTEXT
+        LD.32 A0, @pxCurrentTCB
+        LD.32 A15, *A0
+
+        ;Check if task has FPU context
+        LD.32	 D0, *(A15-=#8)
+        ST.32 @ulTaskHasFPUContext, D0
+        || BCMPZ  .+0x4a, D.EQ, D0
+
+        LD.64 XM30, *(A15-=#8)
+        LD.64 XM28, *(A15-=#8)
+        LD.64 XM26, *(A15-=#8)
+        LD.64 XM24, *(A15-=#8)
+        LD.64 XM22, *(A15-=#8)
+        LD.64 XM20, *(A15-=#8)
+        LD.64 XM18, *(A15-=#8)
+        LD.64 XM16, *(A15-=#8)
+        LD.64 XM14, *(A15-=#8)
+        LD.64 XM12, *(A15-=#8)
+        LD.64 XM10, *(A15-=#8)
+        LD.64 XM8,  *(A15-=#8)
+        LD.64 XM6,  *(A15-=#8)
+        LD.64 XM4,  *(A15-=#8)
+        LD.64 XM2,  *(A15-=#8)
+        LD.64 XM0,  *(A15-=#8)
+        
+        LD.64 XD14, *(A15-=#8)
+        LD.64 XD12, *(A15-=#8)
+        LD.64 XD10, *(A15-=#8)
+        LD.64 XD8,  *(A15-=#8)
+        LD.64 XD6,  *(A15-=#8)
+        LD.64 XD4,  *(A15-=#8)
+        LD.64 XD2,  *(A15-=#8)
+        LD.64 XD0,  *(A15-=#8)
+        LD.64 XA12, *(A15-=#8)
+        LD.64 XA10, *(A15-=#8)
+        LD.64 XA8,  *(A15-=#8)
+        LD.64 XA6,  *(A15-=#8)
+        LD.64 XA4,  *(A15-=#8)
+        LD.64 XA2,  *(A15-=#8)
+        LD.64 XA0,  *(A15-=#8)
+        LD.32 ESTS, *(A15-#4)
+        LD.32 DSTS, *(A15-=#8)
+        LD.32 RPC,  *(A15-#4)
+        LD.32 A14,  *(A15-=#8)
+
+    .endm
+
+    .macro portTICK_TIMER_CLEAR_OVERFLOW
+        ; Clear CPUTIMER overflow bit
+        MV  A4, #PORT_TICK_TIMER_O_TCR
+        LD.S16  D0, *(A4)
+        OR      D0, #0x00008000
+        ST.W0 *(A4), D0 
+
+    .endm
+
+portTICK_ISR:
+	; Save the context of the current task.
+    portSAVE_CONTEXT
+
+    ; Clear tick timer and increment tick counter
+    portTICK_TIMER_CLEAR_OVERFLOW
+    CALL     xTaskIncrementTick
+    BCMPZ    skipTaskSwitchContext, D.EQ, D0
+    CALL     @vTaskSwitchContext
+
+skipTaskSwitchContext:
+    ; Restore the context of the task selected to execute.
+    portRESTORE_CONTEXT
+
+    RETI.INT
+
+
+vPortYield:
+	; Save the context of the current task.
+    portSAVE_CONTEXT
+
+    ; Select the next task to execute.
+    CALL      @vTaskSwitchContext
+
+    ; Restore the context of the task selected to execute.
+    portRESTORE_CONTEXT
+    RETI.INT
+
+
+portRESTORE_FIRST_CONTEXT:
+    portRESTORE_CONTEXT
+    RET

--- a/CCS/C2000_C29x_F29H85x/portdefines.h
+++ b/CCS/C2000_C29x_F29H85x/portdefines.h
@@ -1,0 +1,32 @@
+#include "inc/hw_ints.h"
+#include "inc/hw_memmap.h"
+
+//-------------------------------------------------------------------------------------------------
+// FreeRTOS Port Configuration Macros
+//-------------------------------------------------------------------------------------------------
+
+//
+// CPU Timer instance and interrupt in PIPE used for the RTOS tick
+// Ensure that the INT corresponds to the configured CPUTIMER
+//
+#define PORT_TICK_TIMER_BASE        CPUTIMER2_BASE
+#define PORT_TICK_TIMER_INT         INT_TIMER2
+#define PORT_TICK_TIMER_INT_PRI     255U
+
+//
+// SW interrupt in PIPE to use as the interrupt for portYIELD()
+// It is recommended that this be the last interrupt line in the PIPE
+// SW should not use this interrupt line for anything else
+//
+#define PORT_TASK_SWITCH_INT        INT_SW1
+
+//
+// The SW interrupt used for portYIELD() should be the lowest priority
+// SW should not use this interrupt priority for any other interrupt
+//
+#define PORT_TASK_SWITCH_INT_PRI    255U
+
+//-------------------------------------------------------------------------------------------------
+// Derived Macros. DO NOT EDIT!!
+//-------------------------------------------------------------------------------------------------
+#define PORT_TICK_TIMER_O_TCR       ( PORT_TICK_TIMER_BASE + 0x8U )

--- a/CCS/C2000_C29x_F29H85x/portmacro.h
+++ b/CCS/C2000_C29x_F29H85x/portmacro.h
@@ -1,0 +1,173 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+ //	Copyright: Copyright (C) Texas Instruments Incorporated
+//	All rights reserved not granted herein.
+//
+//  Redistribution and use in source and binary forms, with or without 
+//  modification, are permitted provided that the following conditions 
+//  are met:
+//
+//  Redistributions of source code must retain the above copyright 
+//  notice, this list of conditions and the following disclaimer.
+//
+//  Redistributions in binary form must reproduce the above copyright
+//  notice, this list of conditions and the following disclaimer in the 
+//  documentation and/or other materials provided with the   
+//  distribution.
+//
+//  Neither the name of Texas Instruments Incorporated nor the names of
+//  its contributors may be used to endorse or promote products derived
+//  from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+//  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+//  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+//  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+//  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+//  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+//  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+//  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+//-------------------------------------------------------------------------------------------------
+// Port specific definitions.
+//
+// The settings in this file configure FreeRTOS correctly for the
+// given hardware and compiler.
+//
+// These settings should not be altered.
+//-------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------
+// Hardware includes
+//-------------------------------------------------------------------------------------------------
+#include "interrupt.h"
+#include "cputimer.h"
+#include "portdefines.h"
+
+//-------------------------------------------------------------------------------------------------
+// Type definitions.
+//-------------------------------------------------------------------------------------------------
+#define portCHAR        uint8_t
+#define portFLOAT       float
+#define portDOUBLE      double
+#define portLONG        uint32_t
+#define portSHORT       uint16_t
+#define portBASE_TYPE   long
+#define portSTACK_TYPE  uint32_t
+
+typedef portSTACK_TYPE  StackType_t;
+typedef int32_t         BaseType_t;
+typedef uint32_t        UBaseType_t;
+
+#if( configUSE_16_BIT_TICKS == 1 )
+  typedef uint16_t TickType_t;
+  #define portMAX_DELAY ( TickType_t ) 0xffff
+#else
+  typedef uint32_t TickType_t;
+  #define portMAX_DELAY ( TickType_t ) 0xffffffffUL
+#endif
+
+//-------------------------------------------------------------------------------------------------
+// Interrupt control macros.
+//-------------------------------------------------------------------------------------------------
+#define portDISABLE_INTERRUPTS()  __asm__(" DISINT")
+#define portENABLE_INTERRUPTS()   __asm__(" ENINT")
+
+static inline UBaseType_t xPortSetInterruptMask()
+{
+   volatile UBaseType_t dsts;
+   __asm__(" ST.32 *(A15-#8), DSTS");
+   __asm__(" DISINT");
+   return ( ( dsts >> 16 ) & 1 );
+}
+
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( x )  if( x ) __asm__(" ENINT") // Enable only if x is set
+#define portSET_INTERRUPT_MASK_FROM_ISR( )      xPortSetInterruptMask( )
+
+/* Any task that uses the floating point unit MUST call vPortTaskUsesFPU()
+before any floating point instructions are executed. */
+void vPortTaskUsesFPU( void );
+
+//-------------------------------------------------------------------------------------------------
+// Architecture specific optimisations.
+//-------------------------------------------------------------------------------------------------
+#if configUSE_PORT_OPTIMISED_TASK_SELECTION == 1
+
+/* Store/clear the ready priorities in a bit map. */
+    #define portRECORD_READY_PRIORITY( uxPriority, uxReadyPriorities )    ( uxReadyPriorities ) |= ( 1UL << ( uxPriority ) )
+    #define portRESET_READY_PRIORITY( uxPriority, uxReadyPriorities )     ( uxReadyPriorities ) &= ~( 1UL << ( uxPriority ) )
+
+/*-----------------------------------------------------------*/
+
+    #define portGET_HIGHEST_PRIORITY( uxTopPriority, uxReadyPriorities )  uxTopPriority = ( 31 - __builtin_c29_i32_clzeros_d( ( uxReadyPriorities ) ) )
+
+#endif /* configUSE_PORT_OPTIMISED_TASK_SELECTION */
+
+//-------------------------------------------------------------------------------------------------
+// Critical section control macros.
+//-------------------------------------------------------------------------------------------------
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+
+#define portENTER_CRITICAL()  vPortEnterCritical()
+#define portEXIT_CRITICAL()   vPortExitCritical()
+
+//-------------------------------------------------------------------------------------------------
+// Task utilities.
+//-------------------------------------------------------------------------------------------------
+#define portYIELD()               {Interrupt_force(PORT_TASK_SWITCH_INT); asm(" NOP #8"); asm(" NOP #5");}
+#define portYIELD_FROM_ISR( x )   if( x ) portYIELD()
+
+extern void portTICK_ISR( void );
+extern void vPortYield( void );
+extern void portRESTORE_FIRST_CONTEXT( void );
+extern void vTaskSwitchContext( void );
+
+//-------------------------------------------------------------------------------------------------
+// Hardware specifics.
+//-------------------------------------------------------------------------------------------------
+#define portBYTE_ALIGNMENT      8
+#define portSTACK_GROWTH        ( 1 )
+#define portTICK_PERIOD_MS      ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()               __asm(" NOP")
+
+//-------------------------------------------------------------------------------------------------
+// Task function macros as described on the FreeRTOS.org WEB site.
+//-------------------------------------------------------------------------------------------------
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )  void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )        void vFunction( void *pvParameters )
+
+#endif /* PORTMACRO_H */


### PR DESCRIPTION
Signed-off-by: Arnav Menon [a-menonr@ti.com](mailto:a-menonr@ti.com)

Description
-----------
Add C29x port for TI F29H85x device.

Test Steps
-----------
Test project demo available [here]

Related Issue
-----------
<None>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
