### PR TITLE
Update port files for CCRH and GHS to support Renesas RH850 U2Cx devices.

### DIFF
--- a/CCRH/LICENSE
+++ b/CCRH/LICENSE
@@ -1,4 +1,4 @@
-FreeRTOS Kernel V11.1.0
+FreeRTOS Kernel V11.2.0
 Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 
 SPDX-License-Identifier: MIT

--- a/CCRH/U2x/README.md
+++ b/CCRH/U2x/README.md
@@ -6,7 +6,7 @@ This repository contains the port of FreeRTOS for Renesas RH850/U2x microcontrol
 
 ## Prerequisites
 - Compiler: CC-RH
-- FreeRTOS version 11.1.0
+- FreeRTOS version 11.2.0
 
 | Device   | FPU | FXU | SMP |
 |----------|-----|-----|-----|
@@ -15,10 +15,11 @@ This repository contains the port of FreeRTOS for Renesas RH850/U2x microcontrol
 | U2A16    | Yes | No  | Yes |
 | U2B6     | Yes | Yes | Yes |
 | U2B10    | Yes | Yes | Yes |
+| U2C8     | Yes | No  | Yes |
 
 ## Link to Test Project
 
-The test project can be found in [RH850_U2Ax_CCRH](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/) and [RH850_U2Bx_CCRH](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/). This project contains example tasks and configurations to help you get started with FreeRTOS on the RH850/U2Ax and U2Bx.
+The test project can be found in [RH850_U2Ax_CCRH](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/), [RH850_U2Bx_CCRH](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/) and [RH850_U2Cx_CCRH](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/). This project contains example tasks and configurations to help you get started with FreeRTOS on the RH850/U2Ax, U2Bx, U2Cx.
 
 ## Note
    1. The minimal stack size (configMINIMAL_STACK_SIZE) must be included the reserved memory for nested interrupt. This formula can be referred: `(task_context_size) * (2 + configMAX_INT_NESTING) + Stack_depth_of_taskcode`
@@ -34,7 +35,7 @@ Example:
    3. The `FXU unit` is only available on `core 0`. Users must ensure that FXU operations are restricted to `core 0` by using the `vTaskCoreAffinitySet` function provided by FreeRTOS SMP.
    4. FXU can be enabled by specific compiler option `-DconfigENABLE_FXU`. FPU can be enabled by specific compiler option `-DconfigENABLE_FPU`
    5. The macros `configENABLE_FXU` and `configENABLE_FPU` must be defined in `FreeRTOSConfig.h`.
-   6. This port supports both U2Ax and U2Bx devices. The user must configure `configDEVICE_NAME` with the value `U2Bx_DEVICES` or `U2Ax_DEVICES` to specify which device is being used.
+   6. This port supports U2Ax, U2Bx and U2Cx devices. The user must configure `configDEVICE_NAME` with the value `U2Cx_DEVICES` or `U2Bx_DEVICES` or `U2Ax_DEVICES` to specify which device is being used.
    7. The User can configure the interrupt priority of the OSTM Timer using `configTIMER_INT_PRIORITY`, with 16 levels available (0 being the highest priority and 15 the lowest).
    8. This port also supports the configuration of contiguous CPU cores in FreeRTOS, allowing the user to set task affinity for execution on specific cores or subsets of cores.
 
@@ -44,7 +45,7 @@ Example:
 - **Documentation:**
   - Refer to the official [FreeRTOS documentation](https://www.freertos.org/Documentation/RTOS_book.html) for detailed information on configuring and using FreeRTOS.
   - Consult the [RH850 U2A group user manual hardware manual](https://www.renesas.com/en/document/mah/rh850u2a-eva-group-users-manual-hardware-0?r=1546621) for specific details about the microcontroller.
-  - Consult the [RH850 U2B group user manual hardware manual](https://www.renesas.com/en/document/mah/rh850u2b-flash-memory-users-manual-r01uh0927ej0100?srsltid=AfmBOooTd6sk-_EsdVV0L_Rw0vGMsaoCQ0SSzpmtoScRcxgcwVkLrQwY) for specific details about the microcontroller.
+  - Consult the [RH850 U2B group user manual hardware manual](https://www.renesas.com/en/document/mah/rh850u2b-hardware-users-manual-rev-120-r01uh0923ej0120?r=1539266) for specific details about the microcontroller.
   - For more information about Renesas RH850 microcontrolers, please visit [this website](https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rh850-automotive-mcus)
   - The CC-RH compiler can be downloaded [here](https://www.renesas.com/us/en/software-tool/c-compiler-package-rh850-family#downloads)
 

--- a/CCRH/U2x/port.c
+++ b/CCRH/U2x/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V11.1.0
+ * FreeRTOS Kernel V11.2.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
@@ -60,6 +60,7 @@
 /* Define necessary hardware IO for OSTM timer.
  * - OSTM0 is used by default for device variant U2Bx.
  * - OSTM1 is used by default for device variant U2Ax.
+ * - OSTM0 is used by default for device variant U2Cx.
  * If it conflicts with the application, the application should implement another timer. */
 #if ( configDEVICE_NAME == U2Bx_DEVICES )
     #define portOSTM_EIC_ADDR    ( 0xfff802d0 )
@@ -71,6 +72,11 @@
     #define portOSTMCMP_ADDR     ( 0xffbf0100 )
     #define portOSTMCTL_ADDR     ( 0xffbf0120 )
     #define portOSTMTS_ADDR      ( 0xffbf0114 )
+#elif ( configDEVICE_NAME == U2Cx_DEVICES )
+    #define portOSTM_EIC_ADDR    ( 0xfff8007e )
+    #define portOSTMCMP_ADDR     ( 0xffbf0000 )
+    #define portOSTMCTL_ADDR     ( 0xffbf0020 )
+    #define portOSTMTS_ADDR      ( 0xffbf0014 )
 #endif
 
 #if ( configNUMBER_OF_CORES > 1 )

--- a/CCRH/U2x/portasm.s
+++ b/CCRH/U2x/portasm.s
@@ -1,5 +1,5 @@
 ;/*
-; * FreeRTOS Kernel V11.1.0
+; * FreeRTOS Kernel V11.2.0
 ; * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 ; *
 ; * SPDX-License-Identifier: MIT

--- a/CCRH/U2x/portmacro.h
+++ b/CCRH/U2x/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V11.1.0
+ * FreeRTOS Kernel V11.2.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT

--- a/GHS/U2x/LICENSE
+++ b/GHS/U2x/LICENSE
@@ -1,4 +1,4 @@
-FreeRTOS Kernel V11.1.0
+FreeRTOS Kernel V11.2.0
 Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 
 SPDX-License-Identifier: MIT

--- a/GHS/U2x/README.md
+++ b/GHS/U2x/README.md
@@ -6,7 +6,7 @@ This repository contains the port of FreeRTOS for Renesas RH850/U2x microcontrol
 
 ## Prerequisites
 - Compiler: GHS
-- FreeRTOS version 11.1.0
+- FreeRTOS version 11.2.0
 
 | Device   | FPU | FXU | SMP |
 |----------|-----|-----|-----|
@@ -15,10 +15,11 @@ This repository contains the port of FreeRTOS for Renesas RH850/U2x microcontrol
 | U2A16    | Yes | No  | Yes |
 | U2B6     | Yes | Yes | Yes |
 | U2B10    | Yes | Yes | Yes |
+| U2C8     | Yes | No  | Yes |
 
 ## Link to Test Project
 
-The test project can be found in [RH850_U2Ax_GHS](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/) and [RH850_U2Bx_GHS](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/). This project contains example tasks and configurations to help you get started with FreeRTOS on the RH850/U2Ax and U2Bx.
+The test project can be found in [RH850_U2Ax_GHS](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/), [RH850_U2Bx_GHS](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/) and [RH850_U2Cx_GHS](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port/). This project contains example tasks and configurations to help you get started with FreeRTOS on the RH850/U2Ax, U2Bx and U2Cx.
 
 ## Note
    1. The minimal stack size `configMINIMAL_STACK_SIZE` must be included the reserved memory for nested interrupt. This formula can be referred: `(task_context_size) * (2 + configMAX_INT_NESTING) + Stack_depth_of_taskcode`
@@ -33,7 +34,7 @@ Example:
    ```
    3. The `FXU unit` is only available on `core 0`. Users must ensure that FXU operations are restricted to `core 0` by using the `vTaskCoreAffinitySet` function provided by FreeRTOS SMP.
    4. Set the macro `configENABLE_FXU` to `1` to enable the `FXU unit`; otherwise set `0` to disable `FXU unit`.
-   5. This port supports both U2Ax and U2Bx devices. The user must configure `configDEVICE_NAME` with the value `U2Bx_DEVICES` or `U2Ax_DEVICES` to specify which device is being used.
+   5. This port supports both U2Ax, U2Bx and U2Cx devices. The user must configure `configDEVICE_NAME` with the value `U2Cx_DEVICES` or `U2Bx_DEVICES` or `U2Ax_DEVICES` to specify which device is being used.
    6. The User can configure the interrupt priority of the OSTM Timer using `configTIMER_INT_PRIORITY`, with 16 levels available (0 being the highest priority and 15 the lowest).
    7. This port also supports the configuration of contiguous CPU cores in FreeRTOS, allowing the user to set task affinity for execution on specific cores or subsets of cores.
 
@@ -42,7 +43,7 @@ Example:
 - **Documentation:**
   - Refer to the official [FreeRTOS documentation](https://www.freertos.org/Documentation/RTOS_book.html) for detailed information on configuring and using FreeRTOS.
   - Consult the [RH850 U2A group user manual hardware manual](https://www.renesas.com/en/document/mah/rh850u2a-eva-group-users-manual-hardware-0?r=1546621) for specific details about the microcontroller.
-  - Consult the [RH850 U2B group user manual hardware manual](https://www.renesas.com/en/document/mah/rh850u2b-flash-memory-users-manual-r01uh0927ej0100?srsltid=AfmBOooTd6sk-_EsdVV0L_Rw0vGMsaoCQ0SSzpmtoScRcxgcwVkLrQwY) for specific details about the microcontroller.
+  - Consult the [RH850 U2B group user manual hardware manual](https://www.renesas.com/en/document/mah/rh850u2b-hardware-users-manual-rev-120-r01uh0923ej0120?r=1539266) for specific details about the microcontroller.
   - For more information about Renesas RH850 microcontrolers, please visit [this website](https://www.renesas.com/us/en/products/microcontrollers-microprocessors/rh850-automotive-mcus)
 
 - **Support:**

--- a/GHS/U2x/port.c
+++ b/GHS/U2x/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V11.1.0
+ * FreeRTOS Kernel V11.2.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT
@@ -60,6 +60,7 @@
 /* Define necessary hardware IO for OSTM timer.
  * - OSTM0 is used by default for device variant U2Bx.
  * - OSTM1 is used by default for device variant U2Ax.
+ * - OSTM0 is used by default for device variant U2Cx.
  * If it conflicts with the application, the application should implement another timer. */
 #if ( configDEVICE_NAME == U2Bx_DEVICES )
     #define portOSTM_EIC_ADDR    ( 0xfff802d0 )
@@ -71,6 +72,11 @@
     #define portOSTMCMP_ADDR     ( 0xffbf0100 )
     #define portOSTMCTL_ADDR     ( 0xffbf0120 )
     #define portOSTMTS_ADDR      ( 0xffbf0114 )
+#elif ( configDEVICE_NAME == U2Cx_DEVICES )
+    #define portOSTM_EIC_ADDR    ( 0xfff8007e )
+    #define portOSTMCMP_ADDR     ( 0xffbf0000 )
+    #define portOSTMCTL_ADDR     ( 0xffbf0020 )
+    #define portOSTMTS_ADDR      ( 0xffbf0014 )
 #endif
 
 #if ( configNUMBER_OF_CORES > 1 )

--- a/GHS/U2x/portasm.850
+++ b/GHS/U2x/portasm.850
@@ -1,5 +1,5 @@
 --/*
--- * FreeRTOS Kernel V11.1.0
+-- * FreeRTOS Kernel V11.2.0
 -- * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
 -- *
 -- * SPDX-License-Identifier: MIT

--- a/GHS/U2x/portmacro.h
+++ b/GHS/U2x/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V11.1.0
+ * FreeRTOS Kernel V11.2.0
  * Copyright (C) 2021 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * SPDX-License-Identifier: MIT


### PR DESCRIPTION
Updated port files for CCRH and GHS to support Renesas RH850 U2Cx devices.

Description
-----------
Updated port files for CCRH and GHS to support Renesas U2Cx devices.

Test Steps
-----------
Conducted the Demo project based on [Template for ThirdParty](https://github.com/FreeRTOS/FreeRTOS/blob/main/FreeRTOS/Demo/ThirdParty/Template/README.md). Refer to [FreeRTOS-Partner-Supported-Demos](https://github.com/renesas/FreeRTOS-Partner-Supported-Demos/tree/u2x_port)

Related Issue
-----------
None


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
