### PR TITLE
Cadence/Xtensa: Enabling XT_USE_L2RAM overrides PRIVILEGED_DATA

### DIFF
--- a/Cadence/Xtensa/xtensa_api.h
+++ b/Cadence/Xtensa/xtensa_api.h
@@ -37,8 +37,8 @@
 #include <stdint.h>
 #include <xtensa/hal.h>
 
-#include "mpu_wrappers.h"
 #include "xtensa_context.h"
+#include "mpu_wrappers.h"
 
 
 /* Typedef for C-callable interrupt handler function */

--- a/Cadence/Xtensa/xtensa_config.h
+++ b/Cadence/Xtensa/xtensa_config.h
@@ -225,7 +225,7 @@
     #define XT_L2RAM_SIXTEENTHS                         8
     #define XT_L2CACHE_SIXTEENTHS                       8
 
-    #define portMOVE_PRIVILEGED_DATA    __attribute__( ( section( ".l2ram.bss" ) ) )
+    #define PRIVILEGED_DATA        __attribute__( ( section( ".l2ram.bss" ) ) )
 #endif
 
 /**


### PR DESCRIPTION
- Removed portMOVE_PRIVILEGED_DATA config option after updates to mpu_wrappers.h
- Improvement suggested via FreeRTOS-Kernel PR #1433

<!--- Title -->

Description
-----------
Optional PRIVILEGED_DATA define is now overridden instead of the prior, custom portMOVE_PRIVILEGED_DATA define.
Provides a cleaner and more flexible update for mpu_wrappers.h.
Still allows moving privileged data into L2RAM for improved performance.

Assuming this PR is accepted, I will then bump FreeRTOS-Kernel/PR1433 to point to this submodule + this change as the default commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
